### PR TITLE
Better Interaction

### DIFF
--- a/GoSync/GoSyncController.py
+++ b/GoSync/GoSyncController.py
@@ -42,6 +42,7 @@ except (ImportError, ValueError):
 
 ID_SYNC_TOGGLE = wx.NewId()
 ID_SYNC_NOW = wx.NewId()
+ID_RECALC_USAGE = wx.NewId()
 
 mainWindowStyle = wx.DEFAULT_FRAME_STYLE & (~wx.CLOSE_BOX) & (~wx.MAXIMIZE_BOX) ^ (wx.RESIZE_BORDER)
 HERE=os.path.abspath(os.path.dirname(__file__))
@@ -89,8 +90,14 @@ class PageAccount(wx.Panel):
             self.driveUsageBar.SetStatusMessage("Sorry, could not calculate your Google Drive usage.")
 
     def OnUsageCalculationUpdate(self, event):
-        percent = (event.data * 100)/self.totalFiles
-        self.driveUsageBar.SetStatusMessage("Calculating your categorical usage... (%d%%)\n" % percent)
+        self.totalFiles = event.data
+        self.driveUsageBar.SetStatusMessage("Calculating usage. Files Scanned: %d\n" % self.totalFiles)
+        self.driveUsageBar.SetMoviesUsage(self.sync_model.GetMovieUsage())
+        self.driveUsageBar.SetDocumentUsage(self.sync_model.GetDocumentUsage())
+        self.driveUsageBar.SetOthersUsage(self.sync_model.GetOthersUsage())
+        self.driveUsageBar.SetAudioUsage(self.sync_model.GetAudioUsage())
+        self.driveUsageBar.SetPhotoUsage(self.sync_model.GetPhotoUsage())
+        self.driveUsageBar.RePaint()
 
     def OnUsageCalculationStarted(self, event):
         self.totalFiles = event.data
@@ -135,7 +142,8 @@ class GoSyncController(wx.Frame):
         menu_txt = 'Pause/Resume Sync'
 
         self.CreateMenuItem(menu, menu_txt, self.OnToggleSync, icon=os.path.join(HERE, 'resources/sync-menu.png'), id=ID_SYNC_TOGGLE)
-        self.CreateMenuItem(menu, 'Synch Now!', self.OnSyncNow, icon=os.path.join(HERE, 'resources/sync-menu.png'), id=ID_SYNC_NOW)
+        self.CreateMenuItem(menu, 'Sync Now!', self.OnSyncNow, icon=os.path.join(HERE, 'resources/sync-menu.png'), id=ID_SYNC_NOW)
+        self.CreateMenuItem(menu, 'Recalculate Drive Usage', self.OnRecalculateDriveUsage, icon=os.path.join(HERE, 'resources/sync-menu.png'), id=ID_RECALC_USAGE)
 
         menu.AppendSeparator()
         self.CreateMenuItem(menu, 'A&bout', self.OnAbout, os.path.join(HERE, 'resources/info.png'))
@@ -169,6 +177,7 @@ class GoSyncController(wx.Frame):
         if self.sync_model.IsSyncEnabled():
             self.sb.SetStatusText("Running", 1)
         else:
+            self.sb.SetStatusText("")
             self.sb.SetStatusText("Paused", 1)
 
         GoSyncEventController().BindEvent(self, GOSYNC_EVENT_SYNC_STARTED,
@@ -179,15 +188,49 @@ class GoSyncController(wx.Frame):
                                           self.OnSyncDone)
         GoSyncEventController().BindEvent(self, GOSYNC_EVENT_SYNC_TIMER,
                                           self.OnSyncTimer)
+        GoSyncEventController().BindEvent(self, GOSYNC_EVENT_INTERNET_UNREACHABLE,
+                                          self.OnInternetDown)
         GoSyncEventController().BindEvent(self, GOSYNC_EVENT_SYNC_INV_FOLDER,
                                           self.OnSyncInvalidFolder)
+        GoSyncEventController().BindEvent(self, GOSYNC_EVENT_SCAN_UPDATE,
+                                          self.OnScanUpdate)
+        GoSyncEventController().BindEvent(self, GOSYNC_EVENT_CALCULATE_USAGE_DONE,
+                                          self.OnUsageCalculationDone)
 
         self.sync_model.SetTheBallRolling()
 
+    def OnUsageCalculationDone(self, event):
+        self.sb.SetStatusText("Usage calculation completed.")
+
+    def OnInternetDown(self, event):
+        self.sb.SetStatusText("Network is down")
+        self.sb.SetStatusText("Paused", 1)
+        dial = wx.MessageDialog(None, 'Internet seems to be down. Sync has been paused.\nPlease enable sync after the Internet is reachable.',
+                                'Internet Down', wx.OK | wx.ICON_EXCLAMATION)
+        res = dial.ShowModal()
+        dial.Destroy()
+
     def OnSyncInvalidFolder(self, event):
-        dial = wx.MessageDialog(None, 'Some of the folders to be sync\'ed were not found on remote server.\nPlease check.\n',
+        dial = wx.MessageDialog(None, 'Folder %s is selected for sync. It could not be found on remote server.\nPlease check settings again.\n' % event.data,
                                 'Error', wx.OK | wx.ICON_EXCLAMATION)
         res = dial.ShowModal()
+        dial.Destroy()
+
+    def OnRecalculateDriveUsage(self, event):
+        if self.sync_model.IsCalculatingDriveUsage() == True:
+            dial = wx.MessageDialog(None, 'GoSync is already scaningfiles on drive.',
+                                    'In Progress', wx.OK | wx.ICON_WARNING)
+            res = dial.ShowModal()
+            dial.Destroy()
+            return
+        elif self.sync_model.IsSyncRunning() == True:
+            dial = wx.MessageDialog(None, 'GoSync is currently syncing files from the Drive.\nThe usage will be refreshed later.',
+                                    'In Progress', wx.OK | wx.ICON_WARNING)
+            res = dial.ShowModal()
+            dial.Destroy()
+
+        self.sync_model.ForceDriveUsageCalculation()
+
 
     def OnSyncTimer(self, event):
         unicode_string = event.data.pop()
@@ -205,6 +248,10 @@ class GoSyncController(wx.Frame):
             self.sb.SetStatusText("Sync completed.")
         else:
             self.sb.SetStatusText("Sync failed. Please check the logs.")
+
+    def OnScanUpdate(self, event):
+        unicode_string = event.data.pop()
+        self.sb.SetStatusText(unicode_string.encode('ascii', 'ignore'))
 
     def CreateMenuItem(self, menu, label, func, icon=None, id=None):
         if id:
@@ -247,6 +294,7 @@ class GoSyncController(wx.Frame):
     def OnToggleSync(self, evt):
         if self.sync_model.IsSyncEnabled():
             self.sync_model.StopSync()
+            self.sb.SetStatusText("Sync is paused")
             self.sb.SetStatusText("Paused", 1)
         else:
             self.sync_model.StartSync()

--- a/GoSync/GoSyncEvents.py
+++ b/GoSync/GoSyncEvents.py
@@ -26,6 +26,8 @@ GOSYNC_EVENT_SYNC_UPDATE = '_gosync_sync_update'
 GOSYNC_EVENT_SYNC_DONE = '_gosync_sync_done'
 GOSYNC_EVENT_SYNC_TIMER = '_gosync_sync_timer'
 GOSYNC_EVENT_SYNC_INV_FOLDER = '_gosync_sync_invalid_folder'
+GOSYNC_EVENT_SCAN_UPDATE = '_gosync_scan_update'
+GOSYNC_EVENT_INTERNET_UNREACHABLE = '_gosync_internet_unreachable'
 
 GOSYNC_EVENT_ID_SYNC_STARTED = wx.NewId()
 GOSYNC_EVENT_ID_SYNC_UPDATE = wx.NewId()
@@ -35,6 +37,8 @@ GOSYNC_EVENT_ID_CALCULATE_USAGE_UPDATE = wx.NewId()
 GOSYNC_EVENT_ID_CALCULATE_USAGE_DONE = wx.NewId()
 GOSYNC_EVENT_ID_SYNC_TIMER = wx.NewId()
 GOSYNC_EVENT_ID_SYNC_INV_FOLDER = wx.NewId()
+GOSYNC_EVENT_ID_SCAN_UPDATE = wx.NewId()
+GOSYNC_EVENT_ID_INTERNET_UNREACHABLE = wx.NewId()
 
 class GoSyncEvent(wx.PyEvent):
     def __init__(self, event, data):
@@ -54,6 +58,8 @@ class GoSyncEventController(object):
                     GOSYNC_EVENT_CALCULATE_USAGE_UPDATE: GOSYNC_EVENT_ID_CALCULATE_USAGE_UPDATE,
                     GOSYNC_EVENT_CALCULATE_USAGE_DONE: GOSYNC_EVENT_ID_CALCULATE_USAGE_DONE,
                     GOSYNC_EVENT_SYNC_TIMER: GOSYNC_EVENT_ID_SYNC_TIMER,
+                    GOSYNC_EVENT_SCAN_UPDATE: GOSYNC_EVENT_ID_SCAN_UPDATE,
+                    GOSYNC_EVENT_INTERNET_UNREACHABLE: GOSYNC_EVENT_ID_INTERNET_UNREACHABLE,
                     GOSYNC_EVENT_SYNC_INV_FOLDER: GOSYNC_EVENT_ID_SYNC_INV_FOLDER}
     _sync_listeners = {GOSYNC_EVENT_SYNC_STARTED:[],
                        GOSYNC_EVENT_SYNC_UPDATE: [],
@@ -62,6 +68,8 @@ class GoSyncEventController(object):
                        GOSYNC_EVENT_CALCULATE_USAGE_UPDATE: [],
                        GOSYNC_EVENT_CALCULATE_USAGE_DONE: [],
                        GOSYNC_EVENT_SYNC_TIMER: [],
+                       GOSYNC_EVENT_SCAN_UPDATE: [],
+                       GOSYNC_EVENT_INTERNET_UNREACHABLE: [],
                        GOSYNC_EVENT_SYNC_INV_FOLDER: []}
 
     def __new__(cls, *args, **kwargs):

--- a/GoSync/GoSyncSettingsPage.py
+++ b/GoSync/GoSyncSettingsPage.py
@@ -47,8 +47,6 @@ class SettingsPage(wx.Panel):
         self.dstc.Disable()
         self.cb.Bind(wx.EVT_CHECKBOX, self.SyncSetting)
 
-        btn = wx.Button(self, label="Refresh")
-        btn.Bind(wx.EVT_BUTTON, self.RefreshTree)
         self.Bind(CT.EVT_TREE_ITEM_CHECKED, self.ItemChecked)
 
         GoSyncEventController().BindEvent(self, GOSYNC_EVENT_CALCULATE_USAGE_DONE,
@@ -60,9 +58,7 @@ class SettingsPage(wx.Panel):
         sizer.Add(t1, 0, wx.ALL)
         sizer.Add(self.cb, 0, wx.ALL)
         sizer.Add(self.dstc, 1, wx.EXPAND)
-        sizer.Add(btn, 0, wx.ALL|wx.CENTER, 5)
         self.SetSizer(sizer)
-
 
     def SyncSetting(self, event):
         if self.cb.GetValue():
@@ -77,7 +73,10 @@ class SettingsPage(wx.Panel):
 
     def ItemChecked(self, event):
         folder = self.dstc.GetPyData(event.GetItem())
-        self.sync_model.SetSyncSelection(folder)
+        if event.GetItem().IsChecked():
+            self.sync_model.SetSyncSelection(folder)
+        else:
+            self.sync_model.RemoveSyncSelection(folder)
 
     def MakeDriveTree(self, gnode, tnode):
         file_list = gnode.GetChildren()
@@ -111,7 +110,7 @@ class SettingsPage(wx.Panel):
         self.dstc.DeleteAllItems()
         self.dstc_root = self.dstc.AddRoot("Google Drive Root")
         self.MakeDriveTree(driveTree.GetRoot(), self.dstc_root)
-        self.dstc.ExpandAll()
+        #self.dstc.ExpandAll()
         sync_list = self.sync_model.GetSyncList()
         for d in sync_list:
             if d[0] == 'root':
@@ -121,7 +120,7 @@ class SettingsPage(wx.Panel):
             else:
                 self.cb.SetValue(False)
                 self.dstc.Enable()
-                break
+                #break
 
         item_list = self.GetItemsToBeChecked(sync_list)
         for item in item_list:


### PR DESCRIPTION
o Drive usage calculation is more interactive now
o The local directory is sync'ed only at the startup since
  during the run observer takes care of new/deleted/moved files
o The sync remote/local is more interactive via status bar.
  This way user knows something is happening in the backend.
o There is a detection of network status. If anytime during sync,
  the network goes down, the condition is detected and sync is
  aborted and paused. The user can restart the sync from "File" menu
  when the network comes back.
o When the sync starts, at that time also the network status is
  checked.
o Removed the "Refresh" button from settings page. It wasn't
  doing much but creating troubles like UI freeze etc. That
  problem is fixed now. The control tree is automatically updated
  when the drive usage calculation completes.
o When a directory is unselected from settings page, the directory
  is also deleted from the sync list. So during remote sync, all
  the unchecked directories which were previously synced are skipped.
  During local sync they are checked even when it is removed from
  the sync list. NEED TO FIX THIS
o The sync time is increased to 30 minutes. The user can always
  override this by clicking "Sync Now" from "Files" menu.

Signed-off-by: Himanshu Chauhan <hschauhan@nulltrace.org>